### PR TITLE
Cmakelists changes and update cat48 spec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ add_subdirectory(astlib lib)
 
 set(LIBS astlib ${Poco_LIBRARIES} ${SYSTEM_LIBS})
 include_directories(${Poco_INCLUDE_DIRECTORIES})
+target_include_directories(astlib INTERFACE .)
 
 add_executable(binary2asterix examples/binary2asterix.cpp)
 target_link_libraries(binary2asterix ${LIBS})

--- a/astlib/CMakeLists.txt
+++ b/astlib/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(generator ${Poco_LIBRARIES} ${SYSTEM_LIBS})
 # add the command to generate the source code
 set(GENERATED_MODULE "${CMAKE_CURRENT_SOURCE_DIR}/AsterixItemDictionary")
 set(GENERATED_SOURCE "${GENERATED_MODULE}.cpp")
-set(XML_SPECS_DIR "${CMAKE_SOURCE_DIR}/specs")
+set(XML_SPECS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../specs")
 
 # Zoznam XML ako zavislost pre rebuild src
 file(GLOB XML_SPECS_FILES "${XML_SPECS_DIR}/*.xml")

--- a/specs/asterix_cat048_1_21.xml
+++ b/specs/asterix_cat048_1_21.xml
@@ -91,9 +91,10 @@
                         <BitsValue val="1">Test target report</BitsValue>
                     </Bits>
                     <Bits bit="7">
-                        <BitsShortName>spare</BitsShortName>
-                        <BitsName>spare bit set to 0</BitsName>
-                        <BitsConst>0</BitsConst>                       
+                        <BitsShortName>track.extendedrange</BitsShortName>
+                        <BitsName>ERR</BitsName>
+                        <BitsValue val="0">No Extended Range</BitsValue>
+                        <BitsValue val="1">Extended Range present</BitsValue>                       
                     </Bits>
                     <Bits bit="6">
                         <BitsShortName>track.xpulse</BitsShortName>
@@ -104,13 +105,13 @@
                     <Bits bit="5">
                         <BitsShortName>track.me</BitsShortName>
                         <BitsName>ME</BitsName>
-                        <BitsValue val="0">Default</BitsValue>
+                        <BitsValue val="0">No military emergency</BitsValue>
                         <BitsValue val="1">Military emergency</BitsValue>
                     </Bits>
                     <Bits bit="4">
                         <BitsShortName>track.mi</BitsShortName>
                         <BitsName>MI</BitsName>
-                        <BitsValue val="0">Default</BitsValue>
+                        <BitsValue val="0">No military identification</BitsValue>
                         <BitsValue val="1">Military identification</BitsValue>
                     </Bits>
                     <Bits from="3" to="2">


### PR DESCRIPTION
1. Export the astlib folder as an interface to make including the headers cleaner in files that use the the library. 
2. Update the XML_SPECS_DIR variable to work correctly when the library is included as a module in a larger cmake project. 
3. Update some of the cat48 field definitions to match CAT48 edition 1.3 released 2 November 2021.