### PR TITLE
Fixes to astlibjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib
 loader
 Makefile
 cmake_install.cmake
+package-lock.json
 
 
 # Compiled Object files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ message("++ Build Type: " ${CMAKE_BUILD_TYPE})
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -march=native -Wall")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall")
 endif()
 
 find_package(Poco 1.7.0 REQUIRED COMPONENTS Net Util XML JSON Foundation CONFIG PATHS "/opt/rsys/platform" "d:/opt/rsys/platform")

--- a/astlibjs/CMakeLists.txt
+++ b/astlibjs/CMakeLists.txt
@@ -26,3 +26,4 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
 # Essential library files to link to a node addon
 # You should add this line in every CMake.js based project
 target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} astlib_dll ${Poco_LIBRARIES})
+target_link_directories(${PROJECT_NAME} PRIVATE ../lib ../../lib )


### PR DESCRIPTION
Fix astlibjs to compile with newer version of the Node interface.
Add target_link_directories to the cmake file of astlibjs to make compilation more robust. 
Remove the -march=native flag to make the compiled code more portable.
Update gitignore to ignore package-lock.json.